### PR TITLE
Configurable socket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # imageio-client
 
-## Deploy and Run
+## Build
+
     $ mvn clean package
-    $ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar ...
 
 ## Usage
-    $ imageio_client PUT <ticket_json>
-    $ imageio_client GET <ticket_uuid>
-    $ imageio_client DELETE <ticket_uuid>
-    
+
+    $ imageio_client sock PUT <ticket_json>
+    $ imageio_client sock GET <ticket_uuid>
+    $ imageio_client sock DELETE <ticket_uuid>
+
 ## Examples
-    $ alias imageio_client="java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar"
-    $ imageio_client PUT 
-        "{
-            'uuid': '799030aa-97c3-4354-871e-0adf0556fcbf',
-            'size': 1073741824,
-            'url': 'file://dev/vgname/lvname',
-            'timeout': 3000,
-            'ops': ["read", "write"]
-        }"
-    $ imageio_client GET 799030aa-97c3-4354-871e-0adf0556fcbf
-    $ imageio_client DELETE 799030aa-97c3-4354-871e-0adf0556fcbf
+
+Adding a ticket:
+
+    $ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
+        /path/to/sock \
+        PUT '{
+            "uuid": "799030aa-97c3-4354-871e-0adf0556fcbf",
+            "size": 1073741824,
+            "url": "file:///path/to/image",
+            "timeout": 3000,
+            "ops": ["read", "write"]
+        }'
+
+Get ticket info:
+
+    $ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
+        /path/to/sock \
+        GET 799030aa-97c3-4354-871e-0adf0556fcbf
+
+Delete a ticket:
+
+    $ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
+        /path/to/sock \
+        DELETE 799030aa-97c3-4354-871e-0adf0556fcbf

--- a/src/main/java/imageioclient/Client.java
+++ b/src/main/java/imageioclient/Client.java
@@ -16,18 +16,18 @@ public class Client {
     }
 
     private static void execute(String[] args) {
-        ImageioClient imageioClient = new ImageioClient();
         String ticketId;
+        ImageioClient imageioClient = new ImageioClient(args[0]);
 
-        switch (args[0]) {
+        switch (args[1]) {
             case "GET":
-                ticketId = args[1];
+                ticketId = args[2];
                 Guid ticketGuid = new Guid(ticketId);
                 String ticketStr = imageioClient.getTicket(ticketGuid);
                 System.out.println(ticketStr);
                 break;
             case "PUT":
-                JsonObject ticketJson = new Gson().fromJson(args[1], JsonObject.class);
+                JsonObject ticketJson = new Gson().fromJson(args[2], JsonObject.class);
                 ImageTicket ticket = new ImageTicket(
                         Guid.createGuidFromString(ticketJson.get("uuid").getAsString()),
                         ticketJson.get("size").getAsLong(),
@@ -38,7 +38,7 @@ public class Client {
                 imageioClient.putTicket(ticket);
                 break;
             case "DELETE":
-                ticketId = args[1];
+                ticketId = args[2];
                 imageioClient.deleteTicket(ticketId);
                 break;
             default:
@@ -48,9 +48,9 @@ public class Client {
 
     private static void usage() {
         System.out.println(
-                "Usage:\n" +
-                        "$ client PUT <ticket_json>\n" +
-                        "$ client GET <ticket_uuid>\n" +
-                        "$ client DELETE <ticket_uuid>");
+            "Usage:\n" +
+            "$ client sock PUT <ticket_json>\n" +
+            "$ client sock GET <ticket_uuid>\n" +
+            "$ client sock DELETE <ticket_uuid>");
     }
 }

--- a/src/main/java/imageioclient/ImageioClient.java
+++ b/src/main/java/imageioclient/ImageioClient.java
@@ -22,11 +22,15 @@ import java.util.stream.Collectors;
 
 public class ImageioClient {
 
-    public static String UNIX_SOCKET_PATH = "/run/vdsm/ovirt-imageio-daemon.sock";
     public static String TICKETS_URI = "/tickets/";
     public static int CLIENT_BUFFER_SIZE = 8 * 1024;
 
+    String socketPath;
     DefaultBHttpClientConnection conn;
+
+    public ImageioClient(String socketPath) {
+        this.socketPath = socketPath;
+    }
 
     public String getTicket(Guid ticketUUID) {
         // Create request
@@ -74,7 +78,7 @@ public class ImageioClient {
             return conn;
         }
 
-        File socketFile = new File(UNIX_SOCKET_PATH);
+        File socketFile = new File(socketPath);
         AFUNIXSocket socket;
         try {
             // Create unix socket

--- a/src/main/java/imageioclient/ImageioClient.java
+++ b/src/main/java/imageioclient/ImageioClient.java
@@ -37,13 +37,13 @@ public class ImageioClient {
         BasicHttpEntityEnclosingRequest request = getRequest("GET", TICKETS_URI + ticketUUID);
 
         // Send request and get response
-        HttpEntity entity = sendRequest(request);
+        HttpEntity response = sendRequest(request);
 
         try {
             // Get content
-            BufferedReader reader = new BufferedReader(new InputStreamReader(entity.getContent()));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(response.getContent()));
             String ticket = reader.lines().collect(Collectors.joining());
-            consumeEntity(entity);
+            consumeEntity(response);
             return ticket;
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -60,8 +60,8 @@ public class ImageioClient {
         request.setHeader("content-length", String.valueOf(request.getEntity().getContentLength()));
 
         // Send request and get response
-        HttpEntity requestEntity = sendRequest(request);
-        consumeEntity(requestEntity);
+        HttpEntity response = sendRequest(request);
+        consumeEntity(response);
     }
 
     public void deleteTicket(String ticketUUID) {
@@ -69,8 +69,8 @@ public class ImageioClient {
         BasicHttpEntityEnclosingRequest request = getRequest("DELETE", TICKETS_URI + ticketUUID);
 
         // Send request and get response
-        HttpEntity entity = sendRequest(request);
-        consumeEntity(entity);
+        HttpEntity response = sendRequest(request);
+        consumeEntity(response);
     }
 
     private DefaultBHttpClientConnection getConnection() {


### PR DESCRIPTION
When testing imageio daemon from source, the socket is not created at
/run/vdsm/ovirt-imageio-daemon.sock. This path is also never correct
when the daemon is running on engine. The path to the socket depends on
the deployment and should not be hard-coded in the client.

Here are example runs:

1. Run daemon from source:

    $ ./ovirt-imageio-daemon -c test/conf

2. Add a ticket:

$ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
    /home/nsoffer/src/ovirt-imageio/daemon/test/daemon.sock \
    PUT '{
        "uuid": "799030aa-97c3-4354-871e-0adf0556fcbf",
        "size": 1073741824,
        "url": "file:///path/to/image",
        "timeout": 3000,
        "ops": ["read", "write"]
    }'

3. Getting ticket info

$ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
    /home/nsoffer/src/ovirt-imageio/daemon/test/daemon.sock \
    GET 799030aa-97c3-4354-871e-0adf0556fcbf
{"active": false, "expires": 4675825, "idle_time": 31, "ops": ["[\"read\",\"write\"]"],
"size": 1073741824, "sparse": false, "dirty": false, "timeout": 3000,
"url": "file:///path/to/image", "uuid": "799030aa-97c3-4354-871e-0adf0556fcbf",
"transferred": 0}

4. Deleting a ticket

$ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
    /home/nsoffer/src/ovirt-imageio/daemon/test/daemon.sock \
    DELETE 799030aa-97c3-4354-871e-0adf0556fcbf

5. Getting ticket info for non-existing ticket

$ java -jar target/imageio-client-1.0-SNAPSHOT-jar-with-dependencies.jar \
    /home/nsoffer/src/ovirt-imageio/daemon/test/daemon.sock \
    GET 799030aa-97c3-4354-871e-0adf0556fcbf
No such ticket '799030aa-97c3-4354-871e-0adf0556fcbf'